### PR TITLE
Refactoring translation component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # LanguageLearn
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 16.1.3.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 16.1.3, and currently working with **17.3.1**.
 
 This is a project to practice and consolidate Angular development, including **Angular Materials**, and the **Jest** framework.
 It reimagines a previous application, LanguageLearn, that I wrote in C++ for my own desktop Windows environment and occasionally ported for newer versions of Visual Studio. This new application will be simplified however. The original idea was to create a spaced repetition system that tracked the user's success in recalling phrases translating between English and German and offered them more frequently if the user was having trouble with them.
@@ -32,6 +32,8 @@ I expect to extend the current state of the project in the following ways:
 `npm i @angular/material-moment-adapter`
 
 `npm i moment`
+
+`npm i angular-in-memory-web-api --save`
 
 ## Development server
 

--- a/src/app/edit-translation/edit-translation.component.ts
+++ b/src/app/edit-translation/edit-translation.component.ts
@@ -39,7 +39,8 @@ export class EditTranslationComponent implements OnInit{
   translatedPhrase!:string;
 
   createdDate = new Date();
-  lastTestedDate = new Date();
+  lastTestedDate:Date = new Date(0);
+
   minDate = new Date(2014, 0, 1);
   maxDate = new Date(2030, 0, 1);
 
@@ -82,8 +83,8 @@ export class EditTranslationComponent implements OnInit{
     // The Epoch time value is still correct - it just seems to be *$%£ing the type
     // ... so we have to recreate that...
     this.createdDate = new Date(this.createdDate);
-    this.lastTestedDate = new Date(this.createdDate);
-    modifiedTranslation.createdTime = this.createdDate;    
+    modifiedTranslation.createdTime = this.createdDate;   
+     
     modifiedTranslation.lastTestedDate = this.lastTestedDate;    
     this.dialogRef.close(modifiedTranslation);
   }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -10,7 +10,7 @@
                     <p class="expand">&lt;&lt;</p>
                 </ng-template>
             </button>
-            <app-test (additionTranslationEvent)="onAddTranslation($event)" 
+            <app-test 
             (creationTimeBackEvent)="onCreationTimeBack($event)"
             (creationTimeForwardEvent)="onCreationTimeForward($event)"
             (testedTimeBackEvent)="onTestedTimeBack($event)"
@@ -19,10 +19,11 @@
         </span>
     </section>
     <section>
-        <app-translation *ngFor="let translation of translations" [translation]="translation" (deletionTranslationEvent)="onDeleteTranslation($event)"></app-translation>
+        <app-translation *ngFor="let translation of translationList" [translation]="translation.translation" (deletionTranslationEvent)="onDeleteTranslation($event)"></app-translation>
     </section>
     <section>
         <button type="button" class="supportbutton" (click)="onDone()">Done</button>
         <button type="button" class="supportbutton">Copy</button>
+        <button type="button" class="supportbutton" (click)="onAdd()">Add</button>
     </section>
 </body>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -4,22 +4,22 @@ import { Translation } from '../translation';
 import { TranslationComponent } from '../translation/translation.component';
 import { TestComponent } from '../test/test.component';
 import { LanguageService } from '../services/language.service';
+import { MatDialog, MatDialogConfig, MatDialogModule } from "@angular/material/dialog";
+import { EditTranslationComponent } from '../edit-translation/edit-translation.component';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, TranslationComponent, TestComponent],
+  imports: [CommonModule, TranslationComponent, TestComponent, ],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })
 export class HomeComponent {
 
-  translationList?: TranslationComponent[];
+  translationList: TranslationComponent[] = [];
   displayTestTools:boolean = false;
-  translations: Translation[] = [];
 
-  constructor(private languageService: LanguageService) {
-    console.log(this.translations);
+  constructor(private languageService: LanguageService, public dialog: MatDialog) {
   }
 
   ngOnInit(): void {
@@ -31,68 +31,104 @@ export class HomeComponent {
       .subscribe(translations => this.modifyTranslations(translations));
   }
 
-  modifyTranslations(translations: any){
-    this.translations = translations;
-    for (const translation of translations) {
-      // TODO: this is not the correct place for unpacking - should be in the service
-      translation.createdTime = new Date(Date.parse(translation.createdTime));
-      translation.lastTestedDate = new Date(Date.parse(translation.lastTestedDate));
-    }
+  modifyTranslations(translations: Translation[]){
+    for (const item of translations)
+    {
 
+
+      if (item instanceof Translation) {
+        console.log('item.translation is an instance of Translation');
+        console.log(typeof(item));
+      } else {
+        console.log('item.translation is not an instance of Translation');
+        console.log(typeof(item));
+      }
+
+
+      let translationComponent = new TranslationComponent(this.languageService, this.dialog);
+
+      item.createdTime = new Date(item.createdTime); // required because JSON conversion doesn't handle the date well
+      item.lastTestedDate = new Date(item.lastTestedDate); // required because JSON conversion doesn't handle the date well
+      translationComponent.setTranslationInstance(item);
+      
+      this.translationList.push(translationComponent);
+    }
     console.log(translations);
   }
 
-  onAddTranslation(newTranslation:any){
-    if (newTranslation != undefined){
+  onAdd(){
+    const dialogConfig = new MatDialogConfig();
 
-      let translation = new Translation();
+    // use edit dialog in addition mode
+    dialogConfig.data = {
+      disableClose: true,
+      autoFocus: true,
+      title: 'Add translation'
+    }
 
-      translation.createdTime = newTranslation.createdTime;
-      translation.lastTestedDate = newTranslation.lastTestedDate;
-      translation.sourcePhrase = newTranslation.sourcePhrase;
-      translation.translatedPhrase = newTranslation.translatedPhrase;
-      this.translations.push(translation);
+    const dialogRef = this.dialog.open(EditTranslationComponent, dialogConfig.data)
+
+    dialogRef.afterClosed().subscribe(
+      data => (this.updateList(data))
+    );    
+  }
+
+  updateList (data:Translation){
+    if (data != undefined) // i.e. Save, not Close
+    {
+      console.log("Adding new translation:"); 
+      console.log(data);
+
+      let translationComponent = new TranslationComponent(this.languageService,this.dialog);
+
+      translationComponent.translation = data;
+      this.translationList.push(translationComponent);
+
+      this.languageService.addTranslation(data);
     }
   }
 
   onDone(){
-    this.translations.forEach ((item, index) => {
+  this.translationList.forEach ((item, index) => {
       item.done = true;
-      item.lastTestedDate = new Date();
+      item.translation.lastTestedDate = new Date();
     });
   }
 
-  onDeleteTranslation(newTranslation:any){
-    this.translations.forEach( (item, index) => {
-      if(item === newTranslation) this.translations.splice(index,1);
-    });
+  onDeleteTranslation(id:number){
+    const index = this.translationList.findIndex(item => item.translation.id === id);
+    if (index !== -1) {
+      this.translationList.splice(index, 1);
+    }
+
+    this.languageService.deleteTranslation(id);
   }
 
   onCreationTimeBack(data:any){
-    this.translations.forEach( (item, index) => {
-      item.setCreatedTimeBack();
-      item.done = !item.checkDue();
+    this.translationList.forEach( (item, index) => {
+      item.translation.setCreatedTimeBack();
+      item.done = !item.translation.checkDue();
     });
   }
 
   onCreationTimeForward(data:any){
-    this.translations.forEach( (item, index) => {
-      item.setCreatedTimeForward();
-      item.done = !item.checkDue();
+    this.translationList.forEach( (item, index) => {
+      item.translation.setCreatedTimeForward();
+      item.done = !item.translation.checkDue();
     });
   }
 
   onTestedTimeBack(data:any){
-    this.translations.forEach( (item, index) => {
-      item.setTestedTimeBack();
-      item.done = !item.checkDue();
+    this.translationList.forEach( (item, index) => {
+      item.translation.setTestedTimeBack();
+      item.done = !item.translation.checkDue();
     });
   }
 
   onTestedTimeForward(data:any){
-    this.translations.forEach( (item, index) => {
-      item.setTestedTimeForward();
-      item.done = !item.checkDue();
+    this.translationList.forEach( (item, index) => {
+      item.translation.setTestedTimeForward();
+      item.done = !item.translation.checkDue();
     });
   }
   throwError() {

--- a/src/app/services/language.service.ts
+++ b/src/app/services/language.service.ts
@@ -65,20 +65,20 @@ export class LanguageService {
 
   
   /** PUT: update the translation on the server */
-  /*updateTranslation(translaton: Translation): Observable<any> {
+  updateTranslation(translation: Translation): Observable<any> {
     return this.http.put(this.translationUrl, translation, this.httpOptions).pipe(
       tap(_ => this.log(`updated translation id=${translation.id}`)),
       catchError(this.handleError<any>('updateTranslation'))
     );
-  }*/
+  }
 
   /** POST: add a new translation to the server */
-  /*addTranslation(translation: Translation): Observable<Translation> {
+  addTranslation(translation: Translation): Observable<Translation> {
     return this.http.post<Translation>(this.translationUrl, translation, this.httpOptions).pipe(
       tap((newTranslation: Translation) => this.log(`added translation w/ id=${newTranslation.id}`)),
       catchError(this.handleError<Translation>('addTranslation'))
     );
-  }*/
+  }
 
   /** DELETE: delete the translation from the server */
   deleteTranslation(id: number): Observable<Translation> {

--- a/src/app/translation.ts
+++ b/src/app/translation.ts
@@ -11,7 +11,6 @@ export class Translation{
     public checkDue() : boolean{
         var now = new Date();
 
-        
         const milestones:number[] = [
             1, // 1 day
             2,
@@ -68,10 +67,16 @@ export class Translation{
     }
 
     public setTestedTimeBack(){
-      this.lastTestedDate = new Date(this.lastTestedDate.getTime() - Time.MS_PER_DAY);
+      if (this.lastTestedDate.getTime() != 0)
+      {
+        this.lastTestedDate = new Date(this.lastTestedDate.getTime() - Time.MS_PER_DAY);
+      }
     }
 
     public setTestedTimeForward(){
-      this.lastTestedDate = new Date(this.lastTestedDate.getTime() + Time.MS_PER_DAY);
+      if (this.lastTestedDate.getTime() != 0)
+      {
+        this.lastTestedDate = new Date(this.lastTestedDate.getTime() + Time.MS_PER_DAY);
+      }
     }
 }

--- a/src/app/translation/translation.component.spec.ts
+++ b/src/app/translation/translation.component.spec.ts
@@ -49,11 +49,6 @@ describe('TranslationComponent', () => {
     openDialogExpects();
   });
 
-  it('should open and close add dialog', () => {
-    component.openAddDialog();
-    openDialogExpects();
-  });
-
   // TODO: How do we test saving?
 
 // BOILERPLATE HELPER FUNCTIONS

--- a/src/app/translation/translation.component.ts
+++ b/src/app/translation/translation.component.ts
@@ -6,7 +6,8 @@ import { EditTranslationComponent } from '../edit-translation/edit-translation.c
 import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
 
 import { MatFormFieldModule } from '@angular/material/form-field';
-import {MatDatepickerModule } from '@angular/material/datepicker';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { LanguageService } from '../services/language.service';
 
 enum OpenMode {
   ADD,
@@ -21,50 +22,33 @@ enum OpenMode {
   styleUrls: ['./translation.component.scss'],
 })
 export class TranslationComponent {
-  @Input() translation!: Translation;
+  @Input() translation = new Translation;
   @Input() translationfocus:boolean=false;  
   @Input() due:boolean=false;    
-  @Output() deletionTranslationEvent = new EventEmitter<Translation>();
+  @Output() deletionTranslationEvent = new EventEmitter<number>();
   
   public done:boolean=false;
 
-  constructor(public dialog: MatDialog) {
+  constructor(private languageService: LanguageService, public dialog: MatDialog) {
     this.due = true;
   }
 
   openEditDialog() {
-    this.openDialogAsEdit( true );
-  }
-
-  openAddDialog(){
-    this.openDialogAsEdit( false );
-  }
-
-  // Takes a boolean, because workarounds for scope limitations of enums in JS are just too ugly.
-  openDialogAsEdit(openEdit : boolean ) {
     const dialogConfig = new MatDialogConfig();
 
-    dialogConfig.disableClose = true;
-    dialogConfig.autoFocus = true;
-
-    if (openEdit){ // Edit dialog 
-      dialogConfig.data = {
-        title: 'Edit translation',
-        data: this.translation
-      }
-    } else { // Add dialog
-      dialogConfig.data = {
-        title: 'Add translation',
-        data: this.translation
-      }
+    dialogConfig.data = {
+      disableClose: true,
+      autoFocus: true,
+      title: 'Edit translation',
+      data: this.translation
     }
 
     const dialogRef = this.dialog.open(EditTranslationComponent, dialogConfig.data)
 
     dialogRef.afterClosed().subscribe(
-      data => (this.update(openEdit, data))
+      data => (this.updateTranslation(data))
     );    
-  };
+  }
 
   openDeleteDialog(){
     const dialogConfig = new MatDialogConfig();
@@ -88,25 +72,36 @@ export class TranslationComponent {
   }
 
   deleteTranslation(translation: Translation){
-    this.deletionTranslationEvent.emit(translation);
+    this.deletionTranslationEvent.emit(translation.id);
   }
 
-  update ( editing: boolean , data:any){
+  updateTranslation ( data:Translation){
     if (data != undefined) // i.e. Save, not Close
     {
-      if (editing)
-      {
-        this.translation = data;
-        console.log(data.sourcePhrase);
-        console.log(this.translation.sourcePhrase);
-        console.log(data.createdTime);
-        console.log(this.translation.createdTime);
-      }
-      this.due = this.translation.checkDue();
+      this.translation = data;
+
+      console.log(data.sourcePhrase);
+      console.log(this.translation.sourcePhrase);
+      console.log(data.createdTime);
+      console.log(this.translation.createdTime);
+      this.languageService.updateTranslation(data);
+      this.due = this.translation.checkDue();  
     }
   }
 
   setFocus(setF:boolean){
     this.translationfocus = setF;
   };
+
+  setTranslationInstance(translation:Translation)
+  {
+    //this.translation = translation; // won't work, because the original translation is an object, NOT an instance
+
+    this.translation.sourcePhrase = translation.sourcePhrase;
+    this.translation.translatedPhrase = translation.translatedPhrase;
+    this.translation.lastTestedDate = translation.lastTestedDate;
+    this.translation.createdTime = translation.createdTime;
+    this.translation.id = translation.id;
+    this.translation.done = translation.done;
+  }
 }


### PR DESCRIPTION
Refactoring:
- Remove translation array from home component and rely on translation component's ownership of translations
- Resolve confusion between objects and instances of translations
- Move functionality for adding a translation out of the translation component itself

Fix for broken test buttons.
Update of readme file.